### PR TITLE
Improve rand events

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,11 +7,6 @@
 * Observed Game doesn't generate random events
 * **Action.Event**. Inserts in in table ReplayDB:action
 * Game process Action Event. This Action generates by Observer
+* Do we need train collision event in a replay?
 
-### Cold-Down for random events
-
-Time of cold-down depends of "power attack"
-
-
-### Process situation of collision more than 2 trains
-
+### Add fuel for trains

--- a/server/db/map.py
+++ b/server/db/map.py
@@ -133,7 +133,7 @@ def generate_map02(db):
     p12 = db.add_point(x=85, y=120)
 
     # Posts:
-    db.add_post(p1, 'town-one', PostType.TOWN, population=3, product=35, armor=10)
+    db.add_post(p1, 'town-one', PostType.TOWN, population=3, product=60, armor=3)
     db.add_post(p4, 'market-big', PostType.MARKET, product=36, replenishment=2)
     db.add_post(p5, 'market-medium', PostType.MARKET, product=28, replenishment=1)
     db.add_post(p7, 'market-small', PostType.MARKET, product=5, replenishment=1)

--- a/server/defs.py
+++ b/server/defs.py
@@ -25,6 +25,9 @@ class Action(IntEnum):
     OBSERVER = 100
     GAME = 101
 
+    # This actions are not available for client:
+    EVENT = 102
+
 
 class Result(IntEnum):
     """ Server response codes.

--- a/server/entity/event.py
+++ b/server/entity/event.py
@@ -1,5 +1,7 @@
 from enum import IntEnum
 
+from entity.serializable import Serializable
+
 
 class EventType(IntEnum):
     """ Types of an Event.
@@ -13,7 +15,7 @@ class EventType(IntEnum):
     GAME_OVER = 100
 
 
-class Event(object):
+class Event(Serializable):
     """ Event entity defined by: EventType, game tick and additional info.
     """
     def __init__(self, event_type: EventType, tick, **kwargs):

--- a/server/entity/game.py
+++ b/server/entity/game.py
@@ -35,22 +35,19 @@ class Game(Thread):
     def __init__(self, name, map_name=config.MAP_NAME, observed=False):
         super(Game, self).__init__(name=name)
         log(log.INFO, "Create game, name: '{}'".format(self.name))
-        self.replay = None
-        self._observed = observed
-        if not observed:
-            self.replay = DbReplay()
-        self._lock = Lock()
-        self._current_game_id = 0
-        self._current_tick = 0
-        self.players = {}
+        self.observed = observed
+        self.replay = None if self.observed else DbReplay()
         self.map = Map(map_name)
+        self.current_game_id = 0 if self.observed else self.replay.add_game(name, map_name=self.map.name)
+        self.current_tick = 0
+        self.players = {}
         self.name = name
         self.trains = {}
+        self.skip_next_tick = False
+        self.next_train_moves = {}
+        self.event_cooldowns = {}
+        self._lock = Lock()
         self._stop_event = Event()
-        self._pass_next_tick = False
-        self._next_train_moves = {}
-        if not observed:
-            self._current_game_id = self.replay.add_game(name, map_name=self.map.name)
         random.seed()
 
     @staticmethod
@@ -82,15 +79,15 @@ class Game(Thread):
                     self.map.add_train(train)
                     self.trains[train.idx] = train
                     # Put the Train into Town:
-                    self.put_train_into_town(train)
+                    self.put_train_into_town(train, with_cooldown=False)
                 log(log.INFO, "Add new player to the game, player: {}".format(player))
-            if not self._observed:
+            if not self.observed:
                 Thread.start(self)
 
     def turn(self):
         """ Makes next turn.
         """
-        self._pass_next_tick = True
+        self.skip_next_tick = True
         with self._lock:
             self.tick()
             if self.replay:
@@ -114,13 +111,13 @@ class Game(Thread):
         try:
             while not self._stop_event.wait(config.TICK_TIME):
                 with self._lock:
-                    if self._pass_next_tick:
-                        self._pass_next_tick = False
+                    if self.skip_next_tick:
+                        self.skip_next_tick = False
                     else:
                         self.tick()
                         if replay:
                             replay.add_action(
-                                Action.TURN, message=None, with_commit=False, game_id=self._current_game_id
+                                Action.TURN, message=None, with_commit=False, game_id=self.current_game_id
                             )
             if replay:
                 replay.commit()
@@ -131,8 +128,9 @@ class Game(Thread):
     def tick(self):
         """ Makes game tick. Updates dynamic game entities.
         """
-        self._current_tick += 1
-        log(log.INFO, "Game tick, tick number: {}".format(self._current_tick))
+        self.current_tick += 1
+        log(log.INFO, "Game tick, tick number: {}".format(self.current_tick))
+        self.update_cooldowns_on_tick()  # Update cooldowns in the beginning of the tick.
         self.update_posts_on_tick()
         self.update_trains_positions_on_tick()
         self.handle_trains_collisions_on_tick()
@@ -160,8 +158,8 @@ class Game(Thread):
     def apply_next_train_move(self, train: Train):
         """ Applies postponed Train MOVE if it exist.
         """
-        if train.idx in self._next_train_moves:
-            next_move = self._next_train_moves[train.idx]
+        if train.idx in self.next_train_moves:
+            next_move = self.next_train_moves[train.idx]
             # If next line the same as previous:
             if next_move['line_idx'] == train.line_idx:
                 if train.speed > 0 and train.position == self.map.line[train.line_idx].length:
@@ -186,11 +184,15 @@ class Game(Thread):
         with self._lock:
             if train_idx not in self.trains:
                 return Result.RESOURCE_NOT_FOUND
-            if train_idx in self._next_train_moves:
-                del self._next_train_moves[train_idx]
+            if train_idx in self.next_train_moves:
+                del self.next_train_moves[train_idx]
             train = self.trains[train_idx]
             if line_idx not in self.map.line:
                 return Result.RESOURCE_NOT_FOUND
+
+            # Check cooldown for the train:
+            if train.cooldown > 0:
+                return Result.BAD_COMMAND
 
             # Stop the train:
             if speed == 0:
@@ -247,7 +249,7 @@ class Game(Thread):
 
                 # This train move request is valid and will be applied later:
                 if switch_line_possible:
-                    self._next_train_moves[train_idx] = {'speed': speed, 'line_idx': line_idx}
+                    self.next_train_moves[train_idx] = {'speed': speed, 'line_idx': line_idx}
                 # This train move request is invalid:
                 else:
                     return Result.PATH_NOT_FOUND
@@ -265,12 +267,12 @@ class Game(Thread):
                 goods = max(min(train.goods, post.product_capacity - post.product), 0)
                 post.product += goods
                 if post.product == post.product_capacity:
-                    post.event.append(GameEvent(EventType.RESOURCE_OVERFLOW, self._current_tick, product=post.product))
+                    post.event.append(GameEvent(EventType.RESOURCE_OVERFLOW, self.current_tick, product=post.product))
             elif train.post_type == PostType.STORAGE:
                 goods = max(min(train.goods, post.armor_capacity - post.armor), 0)
                 post.armor += goods
                 if post.armor == post.armor_capacity:
-                    post.event.append(GameEvent(EventType.RESOURCE_OVERFLOW, self._current_tick, armor=post.armor))
+                    post.event.append(GameEvent(EventType.RESOURCE_OVERFLOW, self.current_tick, armor=post.armor))
             train.goods -= goods
             if train.goods == 0:
                 train.post_type = None
@@ -291,7 +293,9 @@ class Game(Thread):
                 train.goods += armor
                 train.post_type = post.type
 
-    def put_train_into_town(self, train: Train, with_unload=True):
+    def put_train_into_town(self, train: Train, with_unload=True, with_cooldown=True):
+        """ Puts given Train to his Town.
+        """
         # Get Train owner's home point:
         player_home_point = self.players[train.player_id].home
         # Use first Line connected to the home point as default train's line:
@@ -308,44 +312,65 @@ class Game(Thread):
         if with_unload:
             train.goods = 0
             train.post_type = None
+        # Set cooldown for the Train:
+        if with_cooldown:
+            # Get Train owner's town:
+            player_town = self.players[train.player_id].town
+            train.cooldown = player_town.train_cooldown_on_collision
 
     def hijackers_assault_on_tick(self):
         """ Makes hijackers assault which decreases quantity of Town's armor and population.
         """
+        # Check cooldown for this Event:
+        if self.event_cooldowns.get(EventType.HIJACKERS_ASSAULT, 0) > 0:
+            return
+
         rand_percent = random.randint(1, 100)
         if rand_percent <= config.HIJACKERS_ASSAULT_PROBABILITY:
             hijackers_power = random.randint(*config.HIJACKERS_POWER_RANGE)
             log(log.INFO, "Hijackers assault happened, hijackers power: {}".format(hijackers_power))
-            event = GameEvent(EventType.HIJACKERS_ASSAULT, self._current_tick, hijackers_power=hijackers_power)
+            event = GameEvent(EventType.HIJACKERS_ASSAULT, self.current_tick, hijackers_power=hijackers_power)
             for player in self.players.values():
                 player.town.population = max(player.town.population - max(hijackers_power - player.town.armor, 0), 0)
                 player.town.armor = max(player.town.armor - hijackers_power, 0)
                 player.town.event.append(event)
             if self.replay:
                 self.replay.add_action(Action.EVENT, event.to_json_str(), with_commit=False)
+            self.event_cooldowns[EventType.HIJACKERS_ASSAULT] = round(
+                hijackers_power * config.HIJACKERS_COOLDOWN_COEF)
 
     def parasites_assault_on_tick(self):
         """ Makes parasites assault which decreases quantity of Town's product.
         """
+        # Check cooldown for this Event:
+        if self.event_cooldowns.get(EventType.PARASITES_ASSAULT, 0) > 0:
+            return
+
         rand_percent = random.randint(1, 100)
         if rand_percent <= config.PARASITES_ASSAULT_PROBABILITY:
             parasites_power = random.randint(*config.PARASITES_POWER_RANGE)
             log(log.INFO, "Parasites assault happened, parasites power: {}".format(parasites_power))
-            event = GameEvent(EventType.PARASITES_ASSAULT, self._current_tick, parasites_power=parasites_power)
+            event = GameEvent(EventType.PARASITES_ASSAULT, self.current_tick, parasites_power=parasites_power)
             for player in self.players.values():
                 player.town.product = max(player.town.product - parasites_power, 0)
                 player.town.event.append(event)
             if self.replay:
                 self.replay.add_action(Action.EVENT, event.to_json_str(), with_commit=False)
+            self.event_cooldowns[EventType.PARASITES_ASSAULT] = round(
+                parasites_power * config.PARASITES_COOLDOWN_COEF)
 
     def refugees_arrival_on_tick(self):
         """ Makes refugees arrival which increases quantity of Town's population.
         """
+        # Check cooldown for this Event:
+        if self.event_cooldowns.get(EventType.REFUGEES_ARRIVAL, 0) > 0:
+            return
+
         rand_percent = random.randint(1, 100)
         if rand_percent <= config.REFUGEES_ARRIVAL_PROBABILITY:
             refugees_number = random.randint(*config.REFUGEES_NUMBER_RANGE)
             log(log.INFO, "Refugees arrival happened, refugees number: {}".format(refugees_number))
-            event = GameEvent(EventType.REFUGEES_ARRIVAL, self._current_tick, refugees_number=refugees_number)
+            event = GameEvent(EventType.REFUGEES_ARRIVAL, self.current_tick, refugees_number=refugees_number)
             for player in self.players.values():
                 player.town.population += max(
                     min(player.town.population_capacity - player.town.population, refugees_number), 0
@@ -353,10 +378,12 @@ class Game(Thread):
                 player.town.event.append(event)
                 if player.town.population == player.town.population_capacity:
                     player.town.event.append(
-                        GameEvent(EventType.RESOURCE_OVERFLOW, self._current_game_id, population=player.town.population)
+                        GameEvent(EventType.RESOURCE_OVERFLOW, self.current_tick, population=player.town.population)
                     )
             if self.replay:
                 self.replay.add_action(Action.EVENT, event.to_json_str(), with_commit=False)
+            self.event_cooldowns[EventType.REFUGEES_ARRIVAL] = round(
+                refugees_number * config.REFUGEES_COOLDOWN_COEF)
 
     def update_posts_on_tick(self):
         """ Updates all markets and storages.
@@ -394,11 +421,11 @@ class Game(Thread):
                 player.town.population = max(player.town.population - 1, 0)
             player.town.product = max(player.town.product - player.town.population, 0)
             if player.town.population == 0:
-                player.town.event.append(GameEvent(EventType.GAME_OVER, self._current_tick, population=0))
+                player.town.event.append(GameEvent(EventType.GAME_OVER, self.current_tick, population=0))
             if player.town.product == 0:
-                player.town.event.append(GameEvent(EventType.RESOURCE_LACK, self._current_tick, product=0))
+                player.town.event.append(GameEvent(EventType.RESOURCE_LACK, self.current_tick, product=0))
             if player.town.armor == 0:
-                player.town.event.append(GameEvent(EventType.RESOURCE_LACK, self._current_tick, armor=0))
+                player.town.event.append(GameEvent(EventType.RESOURCE_LACK, self.current_tick, armor=0))
 
     @staticmethod
     def get_sign(variable):
@@ -434,10 +461,10 @@ class Game(Thread):
         """ Makes collision between two trains.
         """
         log(log.INFO, "Trains collision happened, trains: [{}, {}]".format(train_1, train_2))
-        self.put_train_into_town(train_1, with_unload=True)
-        self.put_train_into_town(train_2, with_unload=True)
-        train_1.event.append(GameEvent(EventType.TRAIN_COLLISION, self._current_tick, train=train_2.idx))
-        train_2.event.append(GameEvent(EventType.TRAIN_COLLISION, self._current_tick, train=train_1.idx))
+        self.put_train_into_town(train_1, with_unload=True, with_cooldown=True)
+        self.put_train_into_town(train_2, with_unload=True, with_cooldown=True)
+        train_1.event.append(GameEvent(EventType.TRAIN_COLLISION, self.current_tick, train=train_2.idx))
+        train_2.event.append(GameEvent(EventType.TRAIN_COLLISION, self.current_tick, train=train_1.idx))
 
     def handle_trains_collisions_on_tick(self):
         """ Handles Trains collisions.
@@ -557,3 +584,16 @@ class Game(Thread):
             train.event = []
         for post in self.map.post.values():
             post.event = []
+
+    def update_cooldowns_on_tick(self):
+        """ Decreases all cooldown values on game tick.
+        """
+        # Update cooldowns for random events:
+        for event in self.event_cooldowns:
+            if self.event_cooldowns[event] != 0:
+                self.event_cooldowns[event] = max(self.event_cooldowns[event] - 1, 0)
+
+        # Update cooldowns for trains:
+        for train in self.trains.values():
+            if train.cooldown != 0:
+                train.cooldown = max(train.cooldown - 1, 0)

--- a/server/entity/game.py
+++ b/server/entity/game.py
@@ -566,11 +566,11 @@ class Game(Thread):
             log(log.INFO, "Load game map layer, layer: {}".format(layer))
             message = self.map.layer_to_json_str(layer)
             self.clean_events()
-            if layer == 1: # add ratings
+            if layer == 1:  # Add ratings.
                 data = json.loads(message)
                 rating = {}
                 for player in self.players.values():
-                    rating[player.name]=player.rating
+                    rating[player.name] = player.rating
                 data['rating'] = rating
                 message = json.dumps(data, sort_keys=True, indent=4)
             return Result.OKEY, message

--- a/server/entity/train.py
+++ b/server/entity/train.py
@@ -29,6 +29,7 @@ class Train(object):
         goods: quantity of some goods in the train at the current moment
         post_type: PostType where first goods have been loaded into the train
         event: all events happened with the Train
+        cooldown: the Train is blocked for this quantity of game ticks
     """
     def __init__(self, idx, line_idx=None, position=None, speed=0, player_id=None, level=1, goods=0, post_type=None):
         self.idx = idx
@@ -44,6 +45,7 @@ class Train(object):
         self.goods = goods
         self.post_type = post_type
         self.event = []
+        self.cooldown = 0
 
     def set_level(self, next_lvl):
         self.level = next_lvl
@@ -53,8 +55,8 @@ class Train(object):
     def __repr__(self):
         return (
             "<Train(idx={}, line_idx={}, position={}, speed={}, player_id={}, "
-            "level={}, goods={}, post_type={})>".format(
+            "level={}, goods={}, post_type={}, cooldown={})>".format(
                 self.idx, self.line_idx, self.position, self.speed, self.player_id,
-                self.level, self.goods, self.post_type
+                self.level, self.goods, self.post_type, self.cooldown
             )
         )

--- a/server/game_config.py
+++ b/server/game_config.py
@@ -8,30 +8,39 @@ class BaseConfig(object):
     MAP_NAME = 'theMap'
     CURRENT_MAP_VERSION = 'map03'
     DEFAULT_TRAINS_COUNT = 2
+
     HIJACKERS_ASSAULT_PROBABILITY = 0
     HIJACKERS_POWER_RANGE = (1, 3)
+    HIJACKERS_COOLDOWN_COEF = 2
+
     PARASITES_ASSAULT_PROBABILITY = 0
     PARASITES_POWER_RANGE = (1, 3)
+    PARASITES_COOLDOWN_COEF = 2
+
     REFUGEES_ARRIVAL_PROBABILITY = 0
     REFUGEES_NUMBER_RANGE = (1, 3)
+    REFUGEES_COOLDOWN_COEF = 2
 
     TOWN_LEVELS = AttrDict({
         1: {
             'population_capacity': 10,
             'product_capacity': 200,
             'armor_capacity': 100,
+            'train_cooldown_on_collision': 8,
             'next_level_price': 100,
         },
         2: {
             'population_capacity': 20,
             'product_capacity': 400,
             'armor_capacity': 200,
+            'train_cooldown_on_collision': 6,
             'next_level_price': 200,
         },
         3: {
             'population_capacity': 40,
             'product_capacity': 800,
             'armor_capacity': 400,
+            'train_cooldown_on_collision': 4,
             'next_level_price': None,
         },
     })
@@ -60,6 +69,9 @@ class BaseConfig(object):
 
 class TestingConfig(BaseConfig):
     DEFAULT_TRAINS_COUNT = 3
+
+
+class TestingConfigWithEvents(TestingConfig):
     HIJACKERS_ASSAULT_PROBABILITY = 100
     HIJACKERS_POWER_RANGE = (1, 1)
     PARASITES_ASSAULT_PROBABILITY = 100
@@ -74,6 +86,7 @@ class ProductionConfig(BaseConfig):
 
 server_configs = {
     'testing': TestingConfig,
+    'testing_with_events': TestingConfigWithEvents,
     'production': ProductionConfig,
 }
 

--- a/server/server.py
+++ b/server/server.py
@@ -50,7 +50,7 @@ class GameServerProtocol(asyncio.Protocol):
                         raise BadCommandError
                     method = self.COMMAND_MAP[self._action]
                     method(self, data)
-                    if self._replay and self._action in (Action.MOVE, Action.LOGIN):
+                    if self._replay and self._action in (Action.MOVE, Action.LOGIN, Action.UPGRADE, ):
                         self._replay.add_action(self._action, self.message, with_commit=False)
             except (json.decoder.JSONDecodeError, BadCommandError):
                 self._write_response(Result.BAD_COMMAND)

--- a/test/game_events.py
+++ b/test/game_events.py
@@ -9,7 +9,7 @@ from server.game_config import config
 from test.server_connection import ServerConnection
 
 
-class TestTrainCollisions(unittest.TestCase):
+class TestGameEvents(unittest.TestCase):
     """ Test class for a Game Player.
     """
     PLAYER_NAME = 'Test Player Name ' + datetime.now().strftime('%H:%M:%S.%f')

--- a/test/game_events.py
+++ b/test/game_events.py
@@ -1,0 +1,179 @@
+import json
+import unittest
+from datetime import datetime
+
+from server.db.map import generate_map02, DbMap
+from server.defs import Action, Result
+from server.entity.event import Event, EventType
+from server.game_config import config
+from test.server_connection import ServerConnection
+
+
+class TestTrainCollisions(unittest.TestCase):
+    """ Test class for a Game Player.
+    """
+    PLAYER_NAME = 'Test Player Name ' + datetime.now().strftime('%H:%M:%S.%f')
+
+    @classmethod
+    def setUpClass(cls):
+        with DbMap() as database:
+            database.reset_db()
+            generate_map02(database)
+
+    @classmethod
+    def tearDownClass(cls):
+        with DbMap() as database:
+            database.reset_db()
+
+    def do_action(self, action, data):
+        return self.connection.do_action(action, data)
+
+    def setUp(self):
+        self.connection = ServerConnection()
+        self.player = self.login()
+        self.current_tick = 0
+
+    def tearDown(self):
+        self.logout()
+        del self.connection
+
+    def login(self):
+        result, message = self.do_action(Action.LOGIN, {'name': self.PLAYER_NAME})
+        self.assertEqual(Result.OKEY, result)
+        return json.loads(message)
+
+    def logout(self):
+        result, _ = self.do_action(Action.LOGOUT, None)
+        self.assertEqual(Result.OKEY, result)
+
+    def turn(self, turns_count=1):
+        for _ in range(turns_count):
+            self.current_tick += 1
+            result, _ = self.do_action(Action.TURN, {})
+            self.assertEqual(Result.OKEY, result)
+
+    def get_post(self, post_id):
+        data = self.get_map(1)
+        posts = {x['idx']: x for x in data['post']}
+        self.assertIn(post_id, posts)
+        return posts[post_id]
+
+    def get_map(self, layer):
+        result, message = self.do_action(Action.MAP, {'layer': layer})
+        self.assertEqual(Result.OKEY, result)
+        return json.loads(message)
+
+    def check_refugees_arrival_event(self, events, ok_event):
+        for event in events:
+            if (event['type'] == ok_event.type
+                    and event['refugees_number'] == ok_event.refugees_number
+                    and event['tick'] == ok_event.tick):
+                return True
+        return False
+
+    def check_hijackers_assault_event(self, events, ok_event):
+        for event in events:
+            if (event['type'] == ok_event.type
+                    and event['hijackers_power'] == ok_event.hijackers_power
+                    and event['tick'] == ok_event.tick):
+                return True
+        return False
+
+    def check_parasites_assault_event(self, events, ok_event):
+        for event in events:
+            if (event['type'] == ok_event.type
+                    and event['parasites_power'] == ok_event.parasites_power
+                    and event['tick'] == ok_event.tick):
+                return True
+        return False
+
+    def test_refugees_arrival(self):
+        turns_num = 6
+        refugees_number = 1  # From game config for testing.
+        town_idx = self.player['town']['idx']
+        turns_ids = [i + 1 for i in range(turns_num)]
+        turns_with_refugees = turns_ids[::config.REFUGEES_COOLDOWN_COEF * refugees_number]
+
+        for _ in range(turns_num):
+            town = self.get_post(town_idx)
+            population_before_turn = town['population']
+            self.turn()
+            town = self.get_post(town_idx)
+            check_event_result = self.check_refugees_arrival_event(
+                town['event'],
+                Event(EventType.REFUGEES_ARRIVAL, self.current_tick, refugees_number=refugees_number)
+            )
+            if self.current_tick in turns_with_refugees:
+                self.assertTrue(check_event_result)
+                self.assertEqual(town['population'], population_before_turn + refugees_number)
+            else:
+                self.assertFalse(check_event_result)
+                self.assertEqual(town['population'], population_before_turn)
+
+    def test_hijackers_assault(self):
+        turns_num = 10
+        hijackers_power = 1  # From game config for testing.
+        refugees_number = 1  # From game config for testing.
+        town_idx = self.player['town']['idx']
+        turns_ids = [i + 1 for i in range(turns_num)]
+        turns_with_assault = turns_ids[::config.HIJACKERS_COOLDOWN_COEF * hijackers_power]
+        turns_with_refugees = turns_ids[::config.REFUGEES_COOLDOWN_COEF * refugees_number]
+
+        for _ in range(turns_num):
+            town = self.get_post(town_idx)
+            armor_before_turn = town['armor']
+            population_before_turn = town['population']
+            self.turn()
+            town = self.get_post(town_idx)
+            check_event_result = self.check_hijackers_assault_event(
+                town['event'],
+                Event(EventType.HIJACKERS_ASSAULT, self.current_tick, hijackers_power=hijackers_power)
+            )
+            if self.current_tick in turns_with_assault:
+                self.assertTrue(check_event_result)
+                armor_after_turn = armor_before_turn - hijackers_power
+                if armor_after_turn >= 0:
+                    self.assertEqual(town['armor'], armor_after_turn)
+                    if self.current_tick in turns_with_refugees:
+                        self.assertEqual(town['population'], population_before_turn + refugees_number)
+                    else:
+                        self.assertEqual(town['population'], population_before_turn)
+                else:
+                    self.assertEqual(town['armor'], 0)
+                    if self.current_tick in turns_with_refugees:
+                        self.assertEqual(
+                            town['population'], max(population_before_turn + refugees_number - hijackers_power, 0))
+                    else:
+                        self.assertEqual(town['population'], max(population_before_turn - hijackers_power, 0))
+            else:
+                self.assertFalse(check_event_result)
+                self.assertEqual(town['armor'], armor_before_turn)
+                if self.current_tick in turns_with_refugees:
+                    self.assertEqual(town['population'], population_before_turn + refugees_number)
+                else:
+                    self.assertEqual(town['population'], population_before_turn)
+
+    def test_parasites_assault(self):
+        turns_num = 6
+        parasites_power = 1  # From game config for testing.
+        town_idx = self.player['town']['idx']
+        turns_ids = [i + 1 for i in range(turns_num)]
+        turns_with_assault = turns_ids[::config.PARASITES_COOLDOWN_COEF * parasites_power]
+
+        for _ in range(turns_num):
+            town = self.get_post(town_idx)
+            product_before_turn = town['product']
+            population_before_turn = town['population']
+            self.turn()
+            town = self.get_post(town_idx)
+            check_event_result = self.check_parasites_assault_event(
+                town['event'],
+                Event(EventType.PARASITES_ASSAULT, self.current_tick, parasites_power=parasites_power)
+            )
+            if self.current_tick in turns_with_assault:
+                self.assertTrue(check_event_result)
+                self.assertEqual(
+                    town['product'], max(product_before_turn - parasites_power - population_before_turn, 0))
+            else:
+                self.assertFalse(check_event_result)
+                self.assertEqual(town['product'], max(product_before_turn - population_before_turn, 0))

--- a/test/train_collisions.py
+++ b/test/train_collisions.py
@@ -435,9 +435,9 @@ class TestTrainCollisions(unittest.TestCase):
             self.move_train(test_line_idx, train_1['idx'], 1, exp_result=Result.BAD_COMMAND)
             self.move_train(test_line_idx, train_2['idx'], 1, exp_result=Result.BAD_COMMAND)
             self.turn()
-
-        map_data = self.get_map(1)
-        self.assertEqual(map_data['train'][0]['cooldown'], 0)
-        self.assertEqual(map_data['train'][1]['cooldown'], 0)
-        self.move_train(test_line_idx, train_1['idx'], 1)
-        self.move_train(test_line_idx, train_2['idx'], 1)
+        else:
+            map_data = self.get_map(1)
+            self.assertEqual(map_data['train'][0]['cooldown'], 0)
+            self.assertEqual(map_data['train'][1]['cooldown'], 0)
+            self.move_train(test_line_idx, train_1['idx'], 1, exp_result=Result.OKEY)
+            self.move_train(test_line_idx, train_2['idx'], 1, exp_result=Result.OKEY)

--- a/test/upgrade.py
+++ b/test/upgrade.py
@@ -270,7 +270,7 @@ class TestUpgrade(unittest.TestCase):
         self.assertEqual(map_data['train'][1]['next_level_price'], curr_train_2['next_level_price'])
 
     def test_upgrade_town(self):
-        trips = 3
+        trips = 4
         test_line_idx = 18
         wait_for_replenishment = 6
         town = self.player['town']

--- a/test/upgrade.py
+++ b/test/upgrade.py
@@ -235,7 +235,7 @@ class TestUpgrade(unittest.TestCase):
             curr_train_1 = self.get_train(train_1['idx'])
             curr_train_2 = self.get_train(train_2['idx'])
             armor = self.get_post(town['idx'])['armor']
-            armor_to_pay = self.get_train(train_1['idx'])['next_level_price']
+            armor_to_pay = curr_train_1['next_level_price']
             # Check that player have enough armor to upgrade train:
             self.assertGreaterEqual(armor, armor_to_pay)
 
@@ -291,14 +291,18 @@ class TestUpgrade(unittest.TestCase):
         self.upgrade(posts=(town['idx'],))
         self.turn()
         map_data = self.get_map(1)
+        town_now = self.get_post(town['idx'])
 
-        self.assertEqual(self.get_post(town['idx'])['armor'],
-                         armor - town['next_level_price'] + train_1_partial_unload['goods'])
-        self.assertEqual(self.get_post(town['idx'])['level'], town['level'] + 1)
-        self.assertGreater(self.get_post(town['idx'])['population_capacity'], town['population_capacity'])
-        self.assertGreater(self.get_post(town['idx'])['product_capacity'], town['product_capacity'])
-        self.assertGreater(self.get_post(town['idx'])['armor_capacity'], town['armor_capacity'])
-        self.assertGreater(self.get_post(town['idx'])['next_level_price'], town['next_level_price'])
+        self.assertEqual(town_now['armor'], armor - town['next_level_price'] + train_1_partial_unload['goods'])
+        self.assertEqual(town_now['level'], town['level'] + 1)
+        self.assertGreater(town_now['population_capacity'], town['population_capacity'])
+        self.assertGreater(town_now['product_capacity'], town['product_capacity'])
+        self.assertGreater(town_now['armor_capacity'], town['armor_capacity'])
+        self.assertGreater(town_now['next_level_price'], town['next_level_price'])
+        self.assertTrue(
+            town_now['train_cooldown_on_collision'] < town['train_cooldown_on_collision']
+            or town_now['train_cooldown_on_collision'] == 0
+        )
 
         self.assertEqual(map_data['train'][0]['level'], train_1['level'])
         self.assertEqual(map_data['train'][0]['goods_capacity'], train_1['goods_capacity'])
@@ -317,13 +321,15 @@ class TestUpgrade(unittest.TestCase):
 
         self.upgrade(posts=(town['idx'],), exp_result=Result.BAD_COMMAND)
         map_data = self.get_map(1)
+        town_now = self.get_post(town['idx'])
 
-        self.assertEqual(self.get_post(town['idx'])['armor'], town['armor'])
-        self.assertEqual(self.get_post(town['idx'])['level'], town['level'])
-        self.assertEqual(self.get_post(town['idx'])['population_capacity'], town['population_capacity'])
-        self.assertEqual(self.get_post(town['idx'])['product_capacity'], town['product_capacity'])
-        self.assertEqual(self.get_post(town['idx'])['armor_capacity'], town['armor_capacity'])
-        self.assertEqual(self.get_post(town['idx'])['next_level_price'], town['next_level_price'])
+        self.assertEqual(town_now['armor'], town['armor'])
+        self.assertEqual(town_now['level'], town['level'])
+        self.assertEqual(town_now['population_capacity'], town['population_capacity'])
+        self.assertEqual(town_now['product_capacity'], town['product_capacity'])
+        self.assertEqual(town_now['armor_capacity'], town['armor_capacity'])
+        self.assertEqual(town_now['next_level_price'], town['next_level_price'])
+        self.assertEqual(town_now['train_cooldown_on_collision'], town['train_cooldown_on_collision'])
 
         self.assertEqual(map_data['train'][0]['level'], train_1['level'])
         self.assertEqual(map_data['train'][0]['goods_capacity'], train_1['goods_capacity'])


### PR DESCRIPTION
Добавил рандомные события в реплей.
Добавил кулдауны для поездов после столкновения и для рандомных событий.
Добавил тесты на кулдауны.
Добавил тесты на рандомные события.

Тесты на рандомные события надо запускать на сервере с другим конфигом:
```
WG_FORGE_SERVER_CONFIG=testing_with_events python server.py
WG_FORGE_SERVER_CONFIG=testing_with_events PYTHONPATH=./server python -m unittest test/game_events.py
```
Остальные тесты надо запускать со стандартным тестовым кофигом:
```
WG_FORGE_SERVER_CONFIG=testing python server.py
WG_FORGE_SERVER_CONFIG=testing PYTHONPATH=./server python -m unittest test/train_collisions.py
```